### PR TITLE
DEV: update deprecated icon home to house

### DIFF
--- a/javascripts/discourse/connectors/footer-nav/footer-nav-exp.gjs
+++ b/javascripts/discourse/connectors/footer-nav/footer-nav-exp.gjs
@@ -277,7 +277,7 @@ export default class FooterNavExp extends Component {
         <span class="footer-nav__item --home">
           <DButton
             @action={{this.goHome}}
-            @icon="home"
+            @icon="house"
             class="btn-flat footer-nav__home
               {{if this.currentRouteHome 'active'}}"
           />


### PR DESCRIPTION
This PR does an update for deprecated icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.