### PR TITLE
UX: wire up create actions

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,5 +2,7 @@ en:
   theme_metadata:
     description: "A theme for Discourse"
   mobile_footer:
-    new_topic: "New Topic"
+    new_topic: "New topic"
+    new_chat: "New chat"
+    new_pm: "New message"
     return_to_hub: "Return to Hub"


### PR DESCRIPTION
This gets the actions behind the ➕ button populated with relevant actions so they function

![image](https://github.com/user-attachments/assets/1b0a3867-653e-4ce5-bcdd-2966e5d4807d)
